### PR TITLE
Add 12 hour patch and scripts for patching

### DIFF
--- a/config/waybar/12hour.patch
+++ b/config/waybar/12hour.patch
@@ -1,0 +1,11 @@
+18c18
+< "clock.time",
+---
+> "custom/time",
+48,49c48,50
+< "clock#time": {
+< "format": "{:%H:%M}",
+---
+> "custom/time": {
+> "exec": "date '+%l:%M %p'",
+> "interval": 1,

--- a/config/waybar/make_12hour.sh
+++ b/config/waybar/make_12hour.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+patch -Ni 12hour.patch config.jsonc

--- a/config/waybar/make_24hour.sh
+++ b/config/waybar/make_24hour.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+patch -Ri 12hour.patch config.jsonc


### PR DESCRIPTION
This PR adds a patch for simple use of a 12 hour clock in Waybar, and two scripts to switch between 12-hour and 24-hour clocks.
Requires #6 for the patch file itself.