### PR TITLE
Add split clock to the taskbar

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -15,8 +15,8 @@
 ],
 
 "modules-center": [
-"clock.time",
-"clock.date"
+"clock#time",
+"clock#date"
 ],
 
 "modules-right": [

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -15,7 +15,8 @@
 ],
 
 "modules-center": [
-"clock"
+"clock.time",
+"clock.date"
 ],
 
 "modules-right": [
@@ -44,8 +45,13 @@
 "tooltip": false
 },
 
-"clock": {
-"format": "{:%H:%M - %a | %d %b %Y}",
+"clock#time": {
+"format": "{:%H:%M}",
+"tooltip": false
+},
+
+"clock#date": {
+"format": "{:%a %d %b %Y}",
 "tooltip": false
 },
 

--- a/config/waybar/opaque-version/config.jsonc
+++ b/config/waybar/opaque-version/config.jsonc
@@ -15,8 +15,8 @@
 ],
 
 "modules-center": [
-"clock.time",
-"clock.date"
+"clock#time",
+"clock#date"
 ],
 
 "modules-right": [

--- a/config/waybar/opaque-version/config.jsonc
+++ b/config/waybar/opaque-version/config.jsonc
@@ -15,7 +15,8 @@
 ],
 
 "modules-center": [
-"clock"
+"clock.time",
+"clock.date"
 ],
 
 "modules-right": [
@@ -44,8 +45,13 @@
 "tooltip": false
 },
 
-"clock": {
-"format": "{:%H:%M - %a | %d %b %Y}",
+"clock#time": {
+"format": "{:%H:%M}",
+"tooltip": false
+},
+
+"clock#date": {
+"format": "{:%a %d %b %Y}",
 "tooltip": false
 },
 

--- a/config/waybar/opaque-version/style.css
+++ b/config/waybar/opaque-version/style.css
@@ -50,6 +50,8 @@ battery
 #battery,
 #network,
 #clock,
+#custom-time,
+#custom-date,
 #tray,
 #pulseaudio {
 background-image: linear-gradient(to bottom, #ffffff, #bbbbbb);
@@ -60,7 +62,23 @@ border-radius: 8px;
 color: rgb(90,90,90);
 text-shadow: 0px 0px 4px rgb(135,135,135);
 }
- 
+
+#custom-time,
+#clock.time {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-right: 0;
+  border-right: 1px solid rgb(135, 135, 135);
+}
+
+#custom-date,
+#clock.date {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 0;
+  border-left: none;
+}
+
 #tray menu {
   background-color: rgba(255,255,255, 0.5);
   color: rgb(90,90,90);

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -82,6 +82,8 @@ tooltip label {
 #battery,
 #network,
 #clock,
+#custom-time,
+#custom-date,
 #tray,
 #workspaces,
 #pulseaudio {
@@ -100,6 +102,22 @@ tooltip label {
   border-bottom-color: rgba(255,255,255,0.15);
   border-top-color: rgba(255,255,255,0.45);
   border-width: 1px;
+}
+
+#custom-time,
+#clock.time {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-right: 0;
+  border-right: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+#custom-date,
+#clock.date {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 0;
+  border-left: none;
 }
 
 #tray menu {

--- a/config/waybar/translucent-version/config.jsonc
+++ b/config/waybar/translucent-version/config.jsonc
@@ -15,8 +15,8 @@
 ],
 
 "modules-center": [
-"clock.time",
-"clock.date"
+"clock#time",
+"clock#date"
 ],
 
 "modules-right": [

--- a/config/waybar/translucent-version/config.jsonc
+++ b/config/waybar/translucent-version/config.jsonc
@@ -15,7 +15,8 @@
 ],
 
 "modules-center": [
-"clock"
+"clock.time",
+"clock.date"
 ],
 
 "modules-right": [
@@ -44,8 +45,13 @@
 "tooltip": false
 },
 
-"clock": {
-"format": "{:%H:%M - %a | %d %b %Y}",
+"clock#time": {
+"format": "{:%H:%M}",
+"tooltip": false
+},
+
+"clock#date": {
+"format": "{:%a %d %b %Y}",
 "tooltip": false
 },
 

--- a/config/waybar/translucent-version/style.css
+++ b/config/waybar/translucent-version/style.css
@@ -82,6 +82,8 @@ tooltip label {
 #battery,
 #network,
 #clock,
+#custom-time,
+#custom-date,
 #tray,
 #workspaces,
 #pulseaudio {
@@ -101,6 +103,23 @@ tooltip label {
   border-top-color: rgba(255,255,255,0.45);
   border-width: 1px;
 }
+
+#custom-time,
+#clock.time {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-right: 0;
+  border-right: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+#custom-date,
+#clock.date {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 0;
+  border-left: none;
+}
+
 
 #tray menu {
   background-color: rgba(255,255,255,0.025);


### PR DESCRIPTION
This PR splits the clock on the taskbar into two combined widgets, one for date, one for time, visually separated by a line
